### PR TITLE
Add side navigation panel

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,20 +4,24 @@ import AlphabetPage from './pages/AlphabetPage'
 import WordsPage from './pages/WordsPage'
 import PhrasesPage from './pages/PhrasesPage'
 import { LanguageProvider } from './useLanguage'
-import NavBar from './components/NavBar'
+import SideNav from './components/SideNav'
 import './index.css'
 
 export default function App() {
   return (
     <LanguageProvider>
       <BrowserRouter>
-        <NavBar />
-        <Routes>
-          <Route path="/" element={<WelcomePage />} />
-          <Route path="/alphabet" element={<AlphabetPage />} />
-          <Route path="/words" element={<WordsPage />} />
-          <Route path="/phrases" element={<PhrasesPage />} />
-        </Routes>
+        <div className="flex min-h-screen">
+          <SideNav />
+          <div className="flex-1">
+            <Routes>
+              <Route path="/" element={<WelcomePage />} />
+              <Route path="/alphabet" element={<AlphabetPage />} />
+              <Route path="/words" element={<WordsPage />} />
+              <Route path="/phrases" element={<PhrasesPage />} />
+            </Routes>
+          </div>
+        </div>
       </BrowserRouter>
     </LanguageProvider>
   )

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -1,0 +1,22 @@
+import { Link } from 'react-router-dom'
+import { useLanguage } from '../useLanguage'
+
+export default function SideNav() {
+  const { t } = useLanguage()
+  return (
+    <nav className="w-48 bg-gray-100 min-h-screen p-4 flex flex-col gap-2">
+      <Link to="/" className="font-semibold">
+        {t('welcome_title')}
+      </Link>
+      <Link to="/alphabet" className="hover:underline">
+        {t('nav_alphabet')}
+      </Link>
+      <Link to="/words" className="hover:underline">
+        {t('nav_words')}
+      </Link>
+      <Link to="/phrases" className="hover:underline">
+        {t('nav_phrases')}
+      </Link>
+    </nav>
+  )
+}

--- a/frontend/src/pages/WelcomePage.tsx
+++ b/frontend/src/pages/WelcomePage.tsx
@@ -1,5 +1,4 @@
 import araratImg from '../assets/ararat.webp'
-import { Link } from 'react-router-dom'
 import { useLanguage } from '../useLanguage'
 
 export default function WelcomePage() {
@@ -9,17 +8,6 @@ export default function WelcomePage() {
       <img src={araratImg} alt="Mount Ararat" className="w-80 rounded" />
       <h1 className="text-2xl font-bold">{t('welcome_title')}</h1>
       <p className="text-center max-w-prose">{t('welcome_desc')}</p>
-      <nav className="flex gap-4 mt-4">
-        <Link className="text-emerald-600 underline" to="/alphabet">
-          {t('nav_alphabet')}
-        </Link>
-        <Link className="text-emerald-600 underline" to="/words">
-          {t('nav_words')}
-        </Link>
-        <Link className="text-emerald-600 underline" to="/phrases">
-          {t('nav_phrases')}
-        </Link>
-      </nav>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add `SideNav` component with navigation links
- wrap routes in a flex layout with `SideNav`
- clean up `WelcomePage` navigation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e95ad815083219f857690db8084ae