### PR TITLE
Fix Tailwind PostCSS plugin usage

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,9 +1,9 @@
-import tailwindcss from 'tailwindcss'
+import tailwindcss from '@tailwindcss/postcss'
 import autoprefixer from 'autoprefixer'
 
 export default {
   plugins: [
-    tailwindcss,
+    tailwindcss(),
     autoprefixer,
   ],
 }


### PR DESCRIPTION
## Summary
- use `@tailwindcss/postcss` plugin in PostCSS config

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684eb032d1088321801f994e8d5e83ce