### PR TITLE
Add boar image to welcome page

### DIFF
--- a/frontend/src/pages/WelcomePage.tsx
+++ b/frontend/src/pages/WelcomePage.tsx
@@ -1,11 +1,17 @@
 import araratImg from '../assets/ararat.webp'
+import boarImg from '../assets/little-boar400x600.webp'
 import { useLanguage } from '../useLanguage'
 
 export default function WelcomePage() {
   const { t } = useLanguage()
   return (
-    <div className="flex flex-col items-center gap-4 p-4">
+    <div className="relative flex flex-col items-center gap-4 p-4">
       <img src={araratImg} alt="Mount Ararat" className="w-320 rounded" />
+      <img
+        src={boarImg}
+        alt="Little boar"
+        className="absolute right-4 bottom-4 w-40"
+      />
       <h1 className="text-4xl font-bold">{t('welcome_title')}</h1>
       <p className="text-2xl text-left max-w-prose">{t('welcome_desc')}</p>
     </div>


### PR DESCRIPTION
## Summary
- show the little boar image in the bottom-right corner of the welcome page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f0c1785448321882c6f8695455972