### PR TITLE
Add popup modal for letters

### DIFF
--- a/frontend/src/components/LetterModal.tsx
+++ b/frontend/src/components/LetterModal.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+
+export interface LetterInfo {
+  image: string
+  wordUpper: string[]
+  wordLower: string[]
+  soundRu: string[]
+  soundEn: string[]
+}
+
+interface LetterModalProps {
+  info: LetterInfo
+  onClose: () => void
+}
+
+export default function LetterModal({ info, onClose }: LetterModalProps) {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50" onClick={onClose}>
+      <div
+        className="bg-white rounded p-4 max-w-sm w-full shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button className="float-right" onClick={onClose}>
+          ✕
+        </button>
+        <img src={info.image} alt="" className="w-full h-auto mb-4" />
+        <table className="table-auto border-collapse w-full text-center">
+          <tbody>
+            <tr>
+              {info.wordUpper.map((l, i) => (
+                <td key={`u${i}`} className="border px-2 py-1 text-2xl">
+                  {l}
+                </td>
+              ))}
+            </tr>
+            <tr>
+              {info.wordLower.map((l, i) => (
+                <td key={`l${i}`} className="border px-2 py-1 text-2xl">
+                  {l}
+                </td>
+              ))}
+            </tr>
+            <tr>
+              {info.soundRu.map((s, i) => (
+                <td key={`r${i}`} className="border px-2 py-1">
+                  {s}
+                </td>
+              ))}
+            </tr>
+            <tr>
+              {info.soundEn.map((s, i) => (
+                <td key={`e${i}`} className="border px-2 py-1">
+                  {s}
+                </td>
+              ))}
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/AlphabetPage.tsx
+++ b/frontend/src/pages/AlphabetPage.tsx
@@ -1,4 +1,17 @@
+import { useState } from 'react'
 import { useLanguage } from '../useLanguage'
+import polarOwl from '../assets/polar_owl.webp'
+import LetterModal, { LetterInfo } from '../components/LetterModal'
+
+const letterInfoMap: Record<string, LetterInfo> = {
+  Բ: {
+    image: polarOwl,
+    wordUpper: ['Բ', 'ՈՒ'],
+    wordLower: ['բ', 'ու'],
+    soundRu: ['Б', 'У'],
+    soundEn: ['b', 'oo'],
+  },
+}
 
 const letters = [
   ['Ա', 'ա', 'A', 'Айб'],
@@ -44,6 +57,13 @@ const letters = [
 
 export default function AlphabetPage() {
   const { t } = useLanguage()
+  const [active, setActive] = useState<LetterInfo | null>(null)
+
+  const openInfo = (letter: string) => {
+    const info = letterInfoMap[letter]
+    if (info) setActive(info)
+  }
+
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">{t('alphabet_title')}</h1>
@@ -59,7 +79,12 @@ export default function AlphabetPage() {
         <tbody>
           {letters.map(([armUpper, armLower, en, ru]) => (
             <tr key={armUpper}>
-              <td className="border px-2 text-center text-2xl">{armUpper}</td>
+              <td
+                className="border px-2 text-center text-2xl cursor-pointer hover:bg-sky-100"
+                onClick={() => openInfo(armUpper)}
+              >
+                {armUpper}
+              </td>
               <td className="border px-2 text-center text-2xl">{armLower}</td>
               <td className="border px-2">{en}</td>
               <td className="border px-2">{ru}</td>
@@ -67,6 +92,9 @@ export default function AlphabetPage() {
           ))}
         </tbody>
       </table>
+      {active && (
+        <LetterModal info={active} onClose={() => setActive(null)} />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- build a modal component to display letter details
- store letter details for Բ and hook it up on alphabet page
- display popup when clicking a letter

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f1296345c8321937cf3f6dc14d148