### PR TITLE
Fix missing type export from LetterModal

### DIFF
--- a/frontend/src/components/LetterModal.tsx
+++ b/frontend/src/components/LetterModal.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 
 export interface LetterInfo {
   image: string

--- a/frontend/src/pages/AlphabetPage.tsx
+++ b/frontend/src/pages/AlphabetPage.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { useLanguage } from '../useLanguage'
 import polarOwl from '../assets/polar_owl.webp'
-import LetterModal, { LetterInfo } from '../components/LetterModal'
+import LetterModal from '../components/LetterModal'
+import type { LetterInfo } from '../components/LetterModal'
 
 const letterInfoMap: Record<string, LetterInfo> = {
   Բ: {


### PR DESCRIPTION
## Summary
- remove unused `React` import from `LetterModal`
- import `LetterInfo` as a type in `AlphabetPage`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f147ef3548321a72e7c4f09d9341c