### PR TITLE
Refactor Interesting Notes strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a minimal React + Flask project for experimenting with Armenian language learning tools.
 
-- Includes basic trainers for the alphabet, words and phrases with EN/RU translation switch.
+- Includes basic trainers for the alphabet, words and phrases with EN/RU translation switch, plus an "Interesting notes" section.
 ## Frontend
 - Vite + React 18 + TypeScript
 - Tailwind CSS for styling

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -12,6 +12,7 @@ export default function NavBar() {
         <Link to="/alphabet">{t('nav_alphabet')}</Link>
         <Link to="/words">{t('nav_words')}</Link>
         <Link to="/phrases">{t('nav_phrases')}</Link>
+        <Link to="/interesting_notes">{t('nav_interesting_notes')}</Link>
       </nav>
       <select
         className="border px-2 py-1"

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -9,6 +9,7 @@ export default function SideNav() {
     { to: '/alphabet', label: t('nav_alphabet') },
     { to: '/words', label: t('nav_words') },
     { to: '/phrases', label: t('nav_phrases') },
+    { to: '/interesting_notes', label: t('nav_interesting_notes') },
   ]
 
   return (

--- a/frontend/src/pages/InterestingNotes.tsx
+++ b/frontend/src/pages/InterestingNotes.tsx
@@ -4,7 +4,7 @@ export default function InterestingNotes() {
   const { t } = useLanguage()
   return (
     <div className="p-4">
-      <h1 className="text-xl font-bold">{t('interesting_notes')}</h1>
+      <h1 className="text-xl font-bold">{t('interesting_notes_title')}</h1>
       <p>{t('coming_soon')}</p>
     </div>
   )

--- a/frontend/src/useLanguage.tsx
+++ b/frontend/src/useLanguage.tsx
@@ -14,6 +14,7 @@ const strings: Record<Lang, Record<string, string>> = {
     nav_alphabet: 'Alphabet trainer',
     nav_words: 'Word trainer',
     nav_phrases: 'Phrase trainer',
+    nav_interesting_notes: 'Interesting notes',
     alphabet_title: 'Armenian Alphabet',
     words_title: 'Simple Words',
     phrases_title: 'Frequent Phrases',
@@ -22,7 +23,7 @@ const strings: Record<Lang, Record<string, string>> = {
     latin: 'Latin',
     russian: 'Russian phonetic',
     lowercase: 'Lowercase',
-    interesting_notes: 'Interesting notes'
+    interesting_notes_title: 'Interesting notes'
   },
   ru: {
     welcome_title: 'Добро пожаловать в тренажеры армянского языка',
@@ -30,6 +31,7 @@ const strings: Record<Lang, Record<string, string>> = {
     nav_alphabet: 'Тренажер алфавита',
     nav_words: 'Тренажер слов',
     nav_phrases: 'Тренажер фраз',
+    nav_interesting_notes: 'любопытные заметки',
     alphabet_title: 'Армянский алфавит',
     words_title: 'Простые слова',
     phrases_title: 'Частые фразы',
@@ -38,7 +40,7 @@ const strings: Record<Lang, Record<string, string>> = {
     latin: 'Латиница',
     russian: 'Русская фонетика',
     lowercase: 'строчная',
-    interesting_notes: 'любопытные заметки'
+    interesting_notes_title: 'любопытные заметки'
   },
 }
 


### PR DESCRIPTION
## Summary
- fix translation key for page header to avoid duplication
- update InterestingNotes page to use the new key

## Testing
- `npm run build` *(fails: TS errors)*
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_684fc17bcffc8321b835d87c021828d8