### PR TITLE
Fix word sound generation

### DIFF
--- a/frontend/src/components/LetterModal.tsx
+++ b/frontend/src/components/LetterModal.tsx
@@ -3,8 +3,8 @@ export interface WordInfo {
   image: string
   wordUpper: string[]
   wordLower: string[]
-  soundRu: string[]
-  soundEn: string[]
+  soundRu?: string[]
+  soundEn?: string[]
 }
 
 interface LetterModalProps {
@@ -16,12 +16,12 @@ export default function LetterModal({ info, onClose }: LetterModalProps) {
   const maxLen = Math.max(
     info.wordUpper.length,
     info.wordLower.length,
-    info.soundRu.length,
-    info.soundEn.length,
+    info.soundRu?.length ?? 0,
+    info.soundEn?.length ?? 0,
   )
 
-  const ruCaps = info.soundRu.map((s) => s.toUpperCase())
-  const enCaps = info.soundEn.map((s) => s.toUpperCase())
+  const ruCaps = (info.soundRu ?? []).map((s) => s.toUpperCase())
+  const enCaps = (info.soundEn ?? []).map((s) => s.toUpperCase())
 
   return (
     <div
@@ -54,12 +54,12 @@ export default function LetterModal({ info, onClose }: LetterModalProps) {
             </tr>
             <tr>
               <td colSpan={maxLen} className="border px-2 py-1 text-center">
-                {info.soundRu.join('')}
+                {(info.soundRu ?? []).join('')}
               </td>
             </tr>
             <tr>
               <td colSpan={maxLen} className="border px-2 py-1 text-center">
-                {info.soundEn.join('')}
+                {(info.soundEn ?? []).join('')}
               </td>
             </tr>
             <tr>

--- a/frontend/src/pages/AlphabetPage.tsx
+++ b/frontend/src/pages/AlphabetPage.tsx
@@ -34,183 +34,131 @@ const wordInfoMap: Record<string, WordInfo> = {
     image: polarOwl,
     wordUpper: ['Բ', 'ՈՒ'],
     wordLower: ['բ', 'ու'],
-    soundRu: ['Б', 'У'],
-    soundEn: ['b', 'oo'],
   },
     Ա: {
     image: appleImg,
     wordUpper: ["Խ", "Ն", "Ձ", "Ո", "Ր"],
     wordLower: ["խ", "ն", "ձ", "ո", "ր"],
-    soundRu: ["Хе", "Ну", "Дза", "Во", "Ре"],
-    soundEn: ["Kh", "N", "Dz", "Vo", "R"],
   },
     Գ: {
     image: apricotImg,
     wordUpper: ["Ծ", "Ի", "Ր", "Ա", "Ն"],
     wordLower: ["ծ", "ի", "ր", "ա", "ն"],
-    soundRu: ["Цо", "Ини", "Ре", "Айб", "Ну"],
-    soundEn: ["Ts", "I", "R", "A", "N"],
   },
     Դ: {
     image: bookImg,
     wordUpper: ["Գ", "Ի", "Ր", "Ք"],
     wordLower: ["գ", "ի", "ր", "ք"],
-    soundRu: ["Гим", "Ини", "Ре", "Кʼе"],
-    soundEn: ["G", "I", "R", "Kʿ"],
   },
     Ե: {
     image: bugImg,
     wordUpper: ["Բ", "Զ", "Ե", "Զ"],
     wordLower: ["բ", "զ", "ե", "զ"],
-    soundRu: ["Бен", "За", "Еч", "За"],
-    soundEn: ["B", "Z", "Ye", "Z"],
   },
     Զ: {
     image: catImg,
     wordUpper: ["Կ", "Ա", "Տ", "ՈՒ"],
     wordLower: ["կ", "ա", "տ", "ու"],
-    soundRu: ["Кен", "Айб", "Тюн", "У"],
-    soundEn: ["K", "A", "T", "U"],
   },
     Է: {
     image: doorImg,
     wordUpper: ["Դ", "ՈՒ", "Ռ"],
     wordLower: ["դ", "ու", "ռ"],
-    soundRu: ["Да", "У", "Ра"],
-    soundEn: ["D", "U", "Rr"],
   },
     Ը: {
     image: earthImg,
     wordUpper: ["Ե", "Ր", "Կ", "Ի", "Ր"],
     wordLower: ["ե", "ր", "կ", "ի", "ր"],
-    soundRu: ["Еч", "Ре", "Кен", "Ини", "Ре"],
-    soundEn: ["Ye", "R", "K", "I", "R"],
   },
     Թ: {
     image: electricCurrentImg,
     wordUpper: ["Հ", "Ո", "Ս", "Ա", "Ն", "Ք"],
     wordLower: ["հ", "ո", "ս", "ա", "ն", "ք"],
-    soundRu: ["Хо", "Во", "Се", "Айб", "Ну", "Кʼе"],
-    soundEn: ["H", "Vo", "S", "A", "N", "Kʿ"],
   },
     Ժ: {
     image: girafImg,
     wordUpper: ["Ը", "Ն", "Ձ", "ՈՒ", "Ղ", "Տ"],
     wordLower: ["ը", "ն", "ձ", "ու", "ղ", "տ"],
-    soundRu: ["Эт", "Ну", "Дза", "У", "Гат", "Тюн"],
-    soundEn: ["Ə", "N", "Dz", "U", "Gh", "T"],
   },
     Ի: {
     image: houseImg,
     wordUpper: ["Տ", "ՈՒ", "Ն"],
     wordLower: ["տ", "ու", "ն"],
-    soundRu: ["Тюн", "У", "Ну"],
-    soundEn: ["T", "U", "N"],
   },
     Լ: {
     image: incubatorImg,
     wordUpper: ["Ի", "Ն", "Կ", "ՈՒ", "Բ", "Ա", "Տ", "Ո", "Ր"],
     wordLower: ["ի", "ն", "կ", "ու", "բ", "ա", "տ", "ո", "ր"],
-    soundRu: ["Ини", "Ну", "Кен", "У", "Бен", "Айб", "Тюн", "Во", "Ре"],
-    soundEn: ["I", "N", "K", "U", "B", "A", "T", "Vo", "R"],
   },
     Խ: {
     image: jewelryImg,
     wordUpper: ["Զ", "Ա", "Ր", "Դ"],
     wordLower: ["զ", "ա", "ր", "դ"],
-    soundRu: ["За", "Айб", "Ре", "Да"],
-    soundEn: ["Z", "A", "R", "D"],
   },
     Ծ: {
     image: lightImg,
     wordUpper: ["Լ", "ՈՒ", "Յ", "Ս"],
     wordLower: ["լ", "ու", "յ", "ս"],
-    soundRu: ["Люн", "У", "Йи", "Се"],
-    soundEn: ["L", "U", "Y", "S"],
   },
     Կ: {
     image: lunchImg,
     wordUpper: ["Ճ", "Ա", "Շ"],
     wordLower: ["ճ", "ա", "շ"],
-    soundRu: ["Че", "Айб", "Ша"],
-    soundEn: ["Ch", "A", "Sh"],
   },
     Հ: {
     image: parrotImg,
     wordUpper: ["Թ", "ՈՒ", "Թ", "Ա", "Կ"],
     wordLower: ["թ", "ու", "թ", "ա", "կ"],
-    soundRu: ["Тхо", "У", "Тхо", "Айб", "Кен"],
-    soundEn: ["Tʿ", "U", "Tʿ", "A", "K"],
   },
     Ձ: {
     image: pourImg,
     wordUpper: ["Լ", "Ց", "Ն", "Ե", "Լ"],
     wordLower: ["լ", "ց", "ն", "ե", "լ"],
-    soundRu: ["Люн", "Цо", "Ну", "Еч", "Люн"],
-    soundEn: ["L", "Tsʿ", "N", "Ye", "L"],
   },
     Ղ: {
     image: raisinImg,
     wordUpper: ["Չ", "Ա", "Մ", "Ի", "Չ"],
     wordLower: ["չ", "ա", "մ", "ի", "չ"],
-    soundRu: ["Ча", "Айб", "Мен", "Ини", "Ча"],
-    soundEn: ["Chʿ", "A", "M", "I", "Chʿ"],
   },
     Ճ: {
     image: steeringWheelImg,
     wordUpper: ["Ղ", "Ե", "Կ"],
     wordLower: ["ղ", "ե", "կ"],
-    soundRu: ["Гат", "Еч", "Кен"],
-    soundEn: ["Gh", "Ye", "K"],
   },
     Պ: {
     image: cheeseImg,
     wordUpper: ["Պ", "Ա", "Ն", "Ի", "Ր"],
     wordLower: ["պ", "ա", "ն", "ի", "ր"],
-    soundRu: ["Пе", "Айб", "Ну", "Ини", "Ре"],
-    soundEn: ["P", "A", "N", "I", "R"],
   },
     Ց: {
     image: bullImg,
     wordUpper: ["Ց", "ՈՒ", "Լ"],
     wordLower: ["ց", "ու", "լ"],
-    soundRu: ["Цо", "У", "Люн"],
-    soundEn: ["Tsʿ", "U", "L"],
   },
     Ջ: {
     image: waterImg,
     wordUpper: ["Ջ", "ՈՒ", "Ր"],
     wordLower: ["ջ", "ու", "ր"],
-    soundRu: ["Дже", "У", "Ре"],
-    soundEn: ["J", "U", "R"],
   },
     Ռ: {
     image: robotImg,
     wordUpper: ["Ռ", "Ո", "Բ", "Ո", "Տ"],
     wordLower: ["ռ", "ո", "բ", "ո", "տ"],
-    soundRu: ["Ра", "Во", "Бен", "Во", "Тюн"],
-    soundEn: ["Rr", "Vo", "B", "Vo", "T"],
   },
     Վ: {
     image: roseImg,
     wordUpper: ["Վ", "Ա", "Ր", "Դ"],
     wordLower: ["վ", "ա", "ր", "դ"],
-    soundRu: ["Вев", "Айб", "Ре", "Да"],
-    soundEn: ["V", "A", "R", "D"],
   },
     Ք: {
     image: stoneImg,
     wordUpper: ["Ք", "Ա", "Ր"],
     wordLower: ["ք", "ա", "ր"],
-    soundRu: ["Кʼе", "Айб", "Ре"],
-    soundEn: ["Kʿ", "A", "R"],
   },
     Օ: {
     image: snakeImg,
     wordUpper: ["Օ", "Ձ"],
     wordLower: ["օ", "ձ"],
-    soundRu: ["О", "Дза"],
-    soundEn: ["O", "Dz"],
   },
 }
 
@@ -256,13 +204,21 @@ const letters = [
   ['Ֆ', 'ֆ', 'F', 'Фе'],
 ]
 
+const letterSoundMap: Record<string, { en: string; ru: string }> = Object.fromEntries(
+  letters.map(([upper, , en, ru]) => [upper, { en, ru }])
+)
+
 export default function AlphabetPage() {
   const { t } = useLanguage()
   const [active, setActive] = useState<WordInfo | null>(null)
 
   const openInfo = (letter: string) => {
     const info = wordInfoMap[letter]
-    if (info) setActive(info)
+    if (info) {
+      const soundRu = info.wordUpper.map((l) => letterSoundMap[l]?.ru ?? '')
+      const soundEn = info.wordUpper.map((l) => letterSoundMap[l]?.en ?? '')
+      setActive({ ...info, soundRu, soundEn })
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- compute word sounds dynamically using letters map
- handle optional fields in `LetterModal`
- update `AlphabetPage` to set `soundRu` and `soundEn` from `wordUpper`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68500be9a7cc83218a6473d8369528bd