### PR TITLE
Fix digraph transliteration for capital ՈՒ

### DIFF
--- a/frontend/src/transliterate.ts
+++ b/frontend/src/transliterate.ts
@@ -39,6 +39,7 @@ const baseMap: [string, string, string][] = [
   ['Ր', 'r', 'р'],
   ['Ց', "ts'", 'ц'],
   ['Ու', 'oo', 'у'],
+  ['ՈՒ', 'oo', 'у'],
   ['Փ', "p'", 'п'],
   ['Ք', "k'", 'к'],
   ['ԵՎ', 'yev', 'ев'],
@@ -53,7 +54,7 @@ for (const [upper, en, ru] of baseMap) {
   letterMap[lower] = { en, ru }
 }
 
-const digraphs = ['Ու', 'ու', 'ԵՎ', 'և']
+const digraphs = ['Ու', 'ու', 'ՈՒ', 'ԵՎ', 'և']
 
 export function transliterate(text: string, lang: TranslitLang): string {
   let result = ''


### PR DESCRIPTION
## Summary
- handle the Armenian capital digraph `ՈՒ`

## Testing
- `npm run lint`
- `npm run build`
- `python -m py_compile api/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68502b8621f48321964e5bd92b90b0de