### PR TITLE
Create first-letter mapping

### DIFF
--- a/frontend/src/pages/AlphabetPage.tsx
+++ b/frontend/src/pages/AlphabetPage.tsx
@@ -255,7 +255,7 @@ const wordInfoMap: Record<string, WordInfo> = {
       wordRu: "камень",
       wordEn: "stone",
   },
-    Օ: {
+  Օ: {
     image: snakeImg,
     wordUpper: ["Օ", "Ձ"],
     wordLower: ["օ", "ձ"],
@@ -265,6 +265,14 @@ const wordInfoMap: Record<string, WordInfo> = {
       wordEn: "snake",
   },
 }
+
+export const wordInfoByFirstLetter: Record<string, WordInfo[]> = Object.values(
+  wordInfoMap,
+).reduce((acc, info) => {
+  const initial = info.wordUpper[0]
+  ;(acc[initial] ??= []).push(info)
+  return acc
+}, {} as Record<string, WordInfo[]>)
 
 const letters = [
   ['Ա', 'ա', 'A', 'Айб'],


### PR DESCRIPTION
## Summary
- generate a `wordInfoByFirstLetter` mapping of `WordInfo` objects grouped by first letter

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685066598b348321befd033d2297ea96