### PR TITLE
Fix article image and text balance

### DIFF
--- a/frontend/src/pages/InterestingNotes.tsx
+++ b/frontend/src/pages/InterestingNotes.tsx
@@ -14,8 +14,12 @@ const notes: Note[] = [
     titleKey: 'note_2025_06_17_title',
     render: (t) => (
       <div className="grid md:grid-cols-2 gap-4 items-start">
-        <img src={architectImg} alt={t('note_2025_06_17_alt')} className="w-full" />
-        <div className="space-y-4">
+        <img
+          src={architectImg}
+          alt={t('note_2025_06_17_alt')}
+          className="w-full md:max-w-xs mx-auto"
+        />
+        <div className="space-y-4 text-lg">
           <p>{t('note_2025_06_17_p1')}</p>
           <p>{t('note_2025_06_17_p2')}</p>
           <p>{t('note_2025_06_17_p3')}</p>


### PR DESCRIPTION
## Summary
- scale down the architect image in Interesting Notes
- make article body text slightly larger

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_685106d196e48321b22ac88b346ff4c6