### PR TITLE
Implement page view tracking

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import usePageViews from './usePageViews'
 import WelcomePage from './pages/WelcomePage'
 import AlphabetPage from './pages/AlphabetPage'
 import WordsPage from './pages/WordsPage'
@@ -12,6 +13,7 @@ export default function App() {
   return (
     <LanguageProvider>
       <BrowserRouter>
+        <TrackPageViews />
         <div className="flex min-h-screen">
           <SideNav />
           <div className="flex-1 ml-64">
@@ -27,4 +29,9 @@ export default function App() {
       </BrowserRouter>
     </LanguageProvider>
   )
+}
+
+function TrackPageViews() {
+  usePageViews()
+  return null
 }

--- a/frontend/src/usePageViews.tsx
+++ b/frontend/src/usePageViews.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+import { analytics } from './firebase'
+import { logEvent } from 'firebase/analytics'
+
+export default function usePageViews() {
+  const location = useLocation()
+
+  useEffect(() => {
+    logEvent(analytics, 'page_view', {
+      page_path: location.pathname + location.search,
+    })
+  }, [location])
+}


### PR DESCRIPTION
## Summary
- log page views in Firebase Analytics
- call the tracking hook in the main app

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852b149d91c832192fa2665cbdfdd99