### PR TITLE
feat: shrink mobile nav text

### DIFF
--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -13,7 +13,7 @@ export default function SideNav() {
   ]
 
   return (
-    <nav className="fixed w-64 min-h-screen bg-sky-200 text-blue-900 p-6 flex flex-col justify-between">
+    <nav className="fixed w-64 min-h-screen bg-sky-200 text-blue-900 p-6 flex flex-col justify-between text-sm sm:text-base">
       <div>
         <Link to="/" className="block uppercase font-bold mb-4">
           {t('welcome_title')}


### PR DESCRIPTION
## Summary
- make side navigation text smaller on mobile screens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689db7bd8e688321ba7ceecca23bfda3